### PR TITLE
fix: Github internal node version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: '24.x'
+          node-version: 24.x
       - run: npm ci
       - run: npm run -w backend lint
       - run: npm run -w frontend lint


### PR DESCRIPTION
- internal node version to get rid of warning