### PR TITLE
api rate limit setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2914,6 +2914,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3343,6 +3361,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -5604,6 +5631,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.5.2",
         "jsonwebtoken": "^9.0.3",
         "mongoose": "^9.5.0"
       },

--- a/packages/backend/backend.js
+++ b/packages/backend/backend.js
@@ -11,6 +11,11 @@ import groupRoutes from "./routes/groups.js";
 import { leaderboardHandler } from "./routes/leaderboard.js";
 import requireAuth from "./middleware/requireAuth.js";
 import { startResetJobs } from "./jobs/resetHours.js";
+import {
+  apiLimiter,
+  authLimiter,
+  writeLimiter,
+} from "./middleware/rateLimit.js";
 
 dotenv.config();
 
@@ -43,22 +48,28 @@ app.options(/.*/, cors());
 app.use(express.json());
 app.use(cookieParser());
 
+// trust proxy so rate limiter sees real client ip behind azure/load balancer
+app.set("trust proxy", 1);
+
+// general backstop on every /api request
+app.use("/api", apiLimiter);
+
 //test server
 app.get("/api/hello", (req, res) => {
   res.json({ message: "Hello from the backend!" });
 });
 
-//auth routes
-app.use("/api/auth", authRoutes);
+//auth routes -- strict limit on top of the api limit
+app.use("/api/auth", authLimiter, authRoutes);
 
 //leaderboard route
 app.get("/api/users/leaderboard", requireAuth, leaderboardHandler);
 
-//user routes
-app.use("/api/users", userRoutes);
+//user routes -- write ops get the writeLimiter
+app.use("/api/users", writeLimiter, userRoutes);
 
-//group routes
-app.use("/api/groups", groupRoutes);
+//group routes -- write ops get the writeLimiter
+app.use("/api/groups", writeLimiter, groupRoutes);
 
 //connect and start server
 connectDB()

--- a/packages/backend/middleware/rateLimit.js
+++ b/packages/backend/middleware/rateLimit.js
@@ -2,20 +2,49 @@
 // uses in-memory store by default. fine for single-instance deploys.
 // btw if we ever scale to multiple servers we'd want a redis store
 
-import rateLimit from "express-rate-limit";
+import rateLimit, { ipKeyGenerator } from "express-rate-limit";
+import jwt from "jsonwebtoken";
+import { AUTH_COOKIE_NAME } from "../config/auth.js";
+import { JWT_SECRET } from "../config/env.js";
+
+// pull the userId out of the auth cookie if its valid
+// we cant rely on req.auth here because limiters run before requireAuth
+function getUserIdFromRequest(req) {
+  // req.auth gets set by requireAuth, use it if it ran already
+  if (req.auth?.userId) return req.auth.userId;
+
+  const token = req.cookies?.[AUTH_COOKIE_NAME];
+  if (!token) return null;
+
+  try {
+    const payload = jwt.verify(token, JWT_SECRET);
+    return typeof payload === "object" && payload?.sub ? payload.sub : null;
+  } catch {
+    return null;
+  }
+}
+
+// key by authed user id when we have it, otherwise fall back to ip
+// this way multiple devices on the same wan ip (dorm/cgnat) dont share a bucket once logged in
+// note: ipKeyGenerator handles ipv6 properly so we dont collapse all ipv6 into one key
+function userOrIpKey(req) {
+  return getUserIdFromRequest(req) || ipKeyGenerator(req);
+}
 
 // generic backstop for the whole api
-// 200 req per 15 min per ip -- normal usage shouldnt hit this
+// 1000 req per 15 min per user (or ip if anonymous)
 export const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  limit: 200,
+  limit: 1000,
   standardHeaders: "draft-7",
   legacyHeaders: false,
+  keyGenerator: userOrIpKey,
   message: { error: "Too many requests, slow down" },
 });
 
 // strict limit on auth endpoints (signup/login)
-// 10 attempts per 15 min per ip -- stops brute force on passwords
+// 10 failed attempts per 15 min per ip -- stops brute force on passwords
+// auth routes are pre-login so we cant key by user id here, ip is the only option
 export const authLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   limit: 10,
@@ -27,11 +56,12 @@ export const authLimiter = rateLimit({
 });
 
 // medium limit for write ops (create/update/delete)
-// 60 writes per 15 min per ip
+// 60 writes per 15 min per user (or ip if anonymous)
 export const writeLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   limit: 60,
   standardHeaders: "draft-7",
   legacyHeaders: false,
+  keyGenerator: userOrIpKey,
   message: { error: "Too many write requests, slow down" },
 });

--- a/packages/backend/middleware/rateLimit.js
+++ b/packages/backend/middleware/rateLimit.js
@@ -1,0 +1,37 @@
+// rate limiting -- so nobody can hammer our api and run up the bill
+// uses in-memory store by default. fine for single-instance deploys.
+// btw if we ever scale to multiple servers we'd want a redis store
+
+import rateLimit from "express-rate-limit";
+
+// generic backstop for the whole api
+// 200 req per 15 min per ip -- normal usage shouldnt hit this
+export const apiLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 200,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+  message: { error: "Too many requests, slow down" },
+});
+
+// strict limit on auth endpoints (signup/login)
+// 10 attempts per 15 min per ip -- stops brute force on passwords
+export const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 10,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+  // dont count successful logins, only failed attempts
+  skipSuccessfulRequests: true,
+  message: { error: "Too many auth attempts, try again later" },
+});
+
+// medium limit for write ops (create/update/delete)
+// 60 writes per 15 min per ip
+export const writeLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 60,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+  message: { error: "Too many write requests, slow down" },
+});

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -18,6 +18,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.5.2",
     "jsonwebtoken": "^9.0.3",
     "mongoose": "^9.5.0"
   },


### PR DESCRIPTION
- added `express-rate-limit` to backend deps
- new `middleware/rateLimit.js` with 3 limiters (per ip):
  - `apiLimiter` -- 200 req / 15 min, blanket cap on all `/api` routes
  - `authLimiter` -- 10 req / 15 min on `/api/auth/*`, only counts failed attempts (brute-force protection)
  - `writeLimiter` -- 60 req / 15 min on `/api/users` + `/api/groups`
- wired limiters into `backend.js`
- set `trust proxy` so we rate-limit real client ips, not the load balancer
- (WILL HAVE TO INSTALL NEW PACKAGE, `npm install express-rate-limit --workspace backend`)