### PR TITLE
Add SPA navigation fallback for Azure routing

### DIFF
--- a/packages/frontend/public/staticwebapp.config.json
+++ b/packages/frontend/public/staticwebapp.config.json
@@ -1,0 +1,6 @@
+{
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": ["/assets/*", "/favicon.svg", "/icons.svg"]
+  }
+}


### PR DESCRIPTION
Added staticwebapp.config.json with a navigation fallback so Azure Static Web Apps serves index.html for all routes, letting React Router handle client-side navigation instead of returning 404s.